### PR TITLE
Entrega das funcionalidades desenvolvidas no Ciclo 5

### DIFF
--- a/src/config/locales/models/lot_question.pt-BR.yml
+++ b/src/config/locales/models/lot_question.pt-BR.yml
@@ -1,0 +1,12 @@
+pt-BR:
+  models:
+    lot_question:
+      one: Esclarecimento
+      other: Esclarecimentos
+
+      attributes:
+        answer: Pergunta
+
+      errors:
+        answer:
+          missing: Resposta não pode ficar em branco

--- a/src/config/locales/views/biddings/lot.pt-BR.yml
+++ b/src/config/locales/views/biddings/lot.pt-BR.yml
@@ -37,6 +37,7 @@ pt-BR:
 
         button:
           proposals: Visualizar propostas
+          lot_questions: Esclarecimentos
 
         files:
           title: Arquivos do lote

--- a/src/config/locales/views/biddings/lots/lot_questions.pt-BR.yml
+++ b/src/config/locales/views/biddings/lots/lot_questions.pt-BR.yml
@@ -1,0 +1,17 @@
+pt-BR:
+  biddings:
+    lots:
+      lot_questions:
+        index:
+          waiting_answer: Aguardando resposta
+        edit:
+          button:
+            submit: Enviar
+            submitting: Enviando
+          form:
+            fields:
+              question_label: Pergunta
+              answer_label: Resposta
+          notifications:
+            success: Esclarecimento atualizado com sucesso
+            failure: Houve um erro ao atualizar o esclarecimento

--- a/src/config/locales/views/biddings/lots/lot_questions.pt-BR.yml
+++ b/src/config/locales/views/biddings/lots/lot_questions.pt-BR.yml
@@ -3,8 +3,13 @@ pt-BR:
     lots:
       lot_questions:
         index:
+          title: Esclarecimentos
           waiting_answer: Aguardando resposta
+          no_lot_questions: Não há perguntas cadastradas
+
         edit:
+          title: Editar esclarecimento
+
           button:
             submit: Enviar
             submitting: Enviando

--- a/src/config/locales/views/biddings/lots/lot_questions.pt-BR.yml
+++ b/src/config/locales/views/biddings/lots/lot_questions.pt-BR.yml
@@ -9,10 +9,17 @@ pt-BR:
 
         edit:
           title: Editar esclarecimento
+          confirm:
+            title: Deseja enviar a resposta?
+            body: Após o envio, a resposta não poderá ser alterada.
+          dialog:
+            back: Voltar
+            confirm: Enviar
 
           button:
             submit: Enviar
             submitting: Enviando
+
           form:
             fields:
               question_label: Pergunta

--- a/src/config/routes.js
+++ b/src/config/routes.js
@@ -40,6 +40,8 @@ import Proposal from '@/views/biddings/lots/proposals/show.vue'
 import GlobalProposals from '@/views/biddings/proposals/index.vue'
 import GlobalProposal from '@/views/biddings/proposals/show.vue'
 
+import LotQuestions from '@/views/biddings/lots/lot_questions/index.vue'
+import EditLotQuestion from '@/views/biddings/lots/lot_questions/edit.vue'
 
 const namespace = null
 
@@ -362,6 +364,28 @@ const routes = [
       transition: { name: 'slide-left' }
     }
   },
+
+  {
+    name:      'LotQuestions',
+    path:      '/biddings/:bidding_id/lots/:lot_id/lot_questions/index',
+    component: LotQuestions,
+    meta:      {
+      auth:       true,
+      back:       true,
+      transition: { name: 'slide-left' }
+    }
+  },
+
+  {
+    name:      'EditLotQuestion',
+    path:      '/biddings/:bidding_id/lots/:lot_id/lot_questions/:id/edit',
+    component: EditLotQuestion,
+    meta:      {
+      auth:       true,
+      back:       true,
+      transition: { name: 'slide-left' }
+    }
+  },  
 
   // TODO componetnes específicos para rotas específicas!
   // Rails tem ErrorsController, com páginas dinâmicas em rotas específicas:

--- a/src/views/biddings/lots/lot_questions/edit.vue
+++ b/src/views/biddings/lots/lot_questions/edit.vue
@@ -2,7 +2,9 @@
 </style>
 
 <template lang="pug">
-  .container
+  .container.mt-2
+    | {{ lot_question.question }}
+
     form(ref="form", method="post", @submit.prevent="submit")
       textarea-field.mt-2(
         v-model="lot_question.answer",
@@ -29,7 +31,30 @@
         i18nScope: 'biddings.lots.lot_questions.edit',
         errors:  {},
         lot_question: {},
-        submitting: false
+        submitting: false,
+
+        tabs: [
+          {
+            route: { name: 'bidding', params: {} },
+            icon: 'fa-file',
+            text: this.$t('models.bidding.one'),
+            active: false,
+          },
+
+          {
+            route: { name: 'lots', params: { bidding_id: null } },
+            icon: 'fa-list',
+            text: this.$t('biddings.lots.index.tabs.lots'),
+            active: true,
+          },
+
+          {
+            route: { name: 'invites', params: {} },
+            icon: 'fa-envelope',
+            text: this.$t('biddings.lots.index.tabs.invites'),
+            active: false,
+          }
+        ]
       }
     },
 
@@ -41,6 +66,18 @@
     },
 
     methods: {
+      getLotQuestion() {
+        return this.$http.get('/cooperative/biddings/' + this.biddingId + '/lots/' + this.lotId + '/lot_questions/' + this.$route.params.id)
+          .then((response) => {
+            this.lot_question = response.data
+
+          }).catch((_err) => {
+            this.error = _err
+            console.error(_err)
+          })
+      },
+
+
       parseRoute() {
         this.biddingId = this.$params.asInteger(this.$route.params.bidding_id)
         this.lotId = this.$params.asInteger(this.$route.params.lot_id)
@@ -69,8 +106,23 @@
           })
       },
 
+      updateTabsRoutes() {
+        this.tabs[0].route.params = { id: this.biddingId }
+        this.tabs[1].route.params = { bidding_id: this.biddingId }
+        this.tabs[2].route.params = { bidding_id: this.biddingId, lot_id: this.lotId }
+
+        this.$emit('tabChanged', this.tabs)
+      },
+
+      updateTitle() {
+        this.$emit('navbarTitleChanged', this.$t('.title'))
+      },
+
       init() {
         this.parseRoute()
+        this.getLotQuestion()
+        this.updateTabsRoutes()
+        this.updateTitle()
       }
     },
 

--- a/src/views/biddings/lots/lot_questions/edit.vue
+++ b/src/views/biddings/lots/lot_questions/edit.vue
@@ -1,0 +1,82 @@
+<style scoped lang="scss">
+</style>
+
+<template lang="pug">
+  .container
+    form(ref="form", method="post", @submit.prevent="submit")
+      textarea-field.mt-2(
+        v-model="lot_question.answer",
+        name="lot_question[answer]",
+        :label="$t('.form.fields.answer_label')",
+        :error="errors.question",
+        require=true,
+        :rows="10"
+      )
+
+      button.button-submit.button-long.u-full-width(
+        type="submit",
+        :disabled="submitting"
+      )
+        | {{ submitText }}
+</template>
+
+<script>
+  export default {
+    name: 'editLotQuestions',
+
+    data () {
+      return {
+        i18nScope: 'biddings.lots.lot_questions.edit',
+        errors:  {},
+        lot_question: {},
+        submitting: false
+      }
+    },
+
+    computed: {
+      submitText() {
+        if (this.submitting) return this.$t('.button.submitting')
+        return this.$t('.button.submit')
+      }
+    },
+
+    methods: {
+      parseRoute() {
+        this.biddingId = this.$params.asInteger(this.$route.params.bidding_id)
+        this.lotId = this.$params.asInteger(this.$route.params.lot_id)
+        this.lotQuestionId = this.$params.asInteger(this.$route.params.id)
+      },
+
+      submit() {
+        const formData = new FormData(this.$refs.form)
+        this.submitting = true
+
+        this.$http.patch('/cooperative/biddings/' + this.biddingId + '/lots/' + this.lotId + '/lot_questions/' + this.lotQuestionId, formData)
+          .then((response) => {
+            this.$notifications.clear()
+            this.errors = {}
+
+            this.$router.replace({ name: 'LotQuestions', params: { bidding_id: this.biddingId, lot_id: this.lotId } })
+          })
+          .catch((err) => {
+            let errors = _.dig(err, 'response', 'data', 'errors') || {}
+
+            this.$notifications.error(this.$t('.notifications.failure'))
+            this.errors = this.$i18n.errify(errors, { model: 'lot_question' })
+          })
+          .then(() => {
+            this.submitting = false
+          })
+      },
+
+      init() {
+        this.parseRoute()
+      }
+    },
+
+    created: function () {
+      this.init();
+    }
+  }
+
+</script>

--- a/src/views/biddings/lots/lot_questions/edit.vue
+++ b/src/views/biddings/lots/lot_questions/edit.vue
@@ -5,7 +5,7 @@
   .container.mt-2
     | {{ lot_question.question }}
 
-    form(ref="form", method="post", @submit.prevent="submit")
+    form(ref="form", method="post", @submit.prevent="confirmSubmit")
       textarea-field.mt-2(
         v-model="lot_question.answer",
         name="lot_question[answer]",
@@ -82,6 +82,26 @@
         this.biddingId = this.$params.asInteger(this.$route.params.bidding_id)
         this.lotId = this.$params.asInteger(this.$route.params.lot_id)
         this.lotQuestionId = this.$params.asInteger(this.$route.params.id)
+      },
+
+      confirmSubmit() {
+        let message = {
+          title: this.$t('.confirm.title'),
+          body: this.$t('.confirm.body')
+        }
+
+        let options = {
+          cancelText: this.$t('.dialog.back'),
+          okText: this.$t('.dialog.confirm')
+        }
+
+        this.$dialog.confirm(message, options)
+          .then((dialog) => {
+            this.submit()
+          })
+          .catch(function (err) {
+            console.log(err)
+          });
       },
 
       submit() {

--- a/src/views/biddings/lots/lot_questions/edit.vue
+++ b/src/views/biddings/lots/lot_questions/edit.vue
@@ -1,4 +1,18 @@
 <style scoped lang="scss">
+  #view {
+    button.button-submit {
+      &.inactive {
+        background-color: $brownish-grey;
+        border-color: $brownish-grey;
+  
+        &:hover {
+          background-color: $brownish-grey;
+          border-color: $brownish-grey;
+          color: $white
+        }
+      }
+    }
+  }
 </style>
 
 <template lang="pug">
@@ -17,7 +31,7 @@
 
       button.button-submit.button-long.u-full-width(
         type="submit",
-        :disabled="submitting"
+        :disabled="isSubmitButtonDisabled", :class="{inactive: isSubmitButtonDisabled}"
       )
         | {{ submitText }}
 </template>
@@ -62,7 +76,18 @@
       submitText() {
         if (this.submitting) return this.$t('.button.submitting')
         return this.$t('.button.submit')
-      }
+      },
+
+      isSubmitButtonDisabled() {
+        if (this.lot_question.answer === undefined ||
+            this.lot_question.answer === null ||
+            this.lot_question.answer.replace(/\s/g,'') === '') {
+
+          return true
+        }
+
+        return false
+      },
     },
 
     methods: {
@@ -76,7 +101,6 @@
             console.error(_err)
           })
       },
-
 
       parseRoute() {
         this.biddingId = this.$params.asInteger(this.$route.params.bidding_id)

--- a/src/views/biddings/lots/lot_questions/index.vue
+++ b/src/views/biddings/lots/lot_questions/index.vue
@@ -5,7 +5,7 @@
   .container.mt-2
     .card.slim.mb-2(v-if="this.lotQuestionsCount > 0")
       ul.mb-0
-        li.list-item.row.p-1(v-for="lotQuestion in lotQuestions", key="lot_question.question", @click="editLotQuestionPath(lotQuestion)")
+        li.list-item.row.p-1(v-for="lotQuestion in lotQuestions", @click="editLotQuestionPath(lotQuestion)")
           .container
             .list-title
               | {{ lotQuestion.question }}

--- a/src/views/biddings/lots/lot_questions/index.vue
+++ b/src/views/biddings/lots/lot_questions/index.vue
@@ -1,0 +1,68 @@
+<style scoped lang="scss">
+</style>
+
+<template lang="pug">
+  .container.mt-2
+    .card.slim.mb-2
+      ul.mb-0
+        li.list-item.row.p-1(v-for="lot_question in lot_questions", key="lot_question.question", @click="editLotQuestionPath(lot_question)")
+          .container
+            .list-title
+              | {{ lot_question.question }}
+            span(v-if="lot_question.answer")
+              | {{ lot_question.answer }}
+            span(v-else)
+              | {{ $t('.waiting_answer') }}
+</template>
+
+<script>
+  export default {
+    name: 'lotQuestions',
+
+    data () {
+      return {
+        i18nScope: 'biddings.lots.lot_questions.index',
+        lot_questions: null,
+        isLoading: true
+      }
+    },
+
+    methods: {
+      fetch() {
+        this.isLoading = true
+
+        return this.$http.get('/cooperative/biddings/' + this.biddingId + '/lots/' + this.lotId + '/lot_questions')
+          .then((response) => {
+            this.lot_questions = response.data
+            this.isLoading = false
+
+          }).catch((_err) => {
+            this.error = _err
+            console.error(_err)
+          })
+      },
+
+      editLotQuestionPath(lot_question) {
+        if (lot_question.answer != null) {
+          return '#!'
+        }
+        
+        this.$router.push({ name: 'EditLotQuestion', params: { bidding_id: this.biddingId, lot_id: this.lotId, id: lot_question.id } })
+      },
+
+      parseRoute() {
+        this.biddingId = this.$params.asInteger(this.$route.params.bidding_id)
+        this.lotId = this.$params.asInteger(this.$route.params.lot_id)
+      },
+
+      init() {
+        this.parseRoute()
+        this.fetch()
+      }      
+    },
+
+    created: function () {
+      this.init();
+    }
+  }
+</script>

--- a/src/views/biddings/lots/lot_questions/index.vue
+++ b/src/views/biddings/lots/lot_questions/index.vue
@@ -3,16 +3,20 @@
 
 <template lang="pug">
   .container.mt-2
-    .card.slim.mb-2
+    .card.slim.mb-2(v-if="this.lotQuestionsCount > 0")
       ul.mb-0
-        li.list-item.row.p-1(v-for="lot_question in lot_questions", key="lot_question.question", @click="editLotQuestionPath(lot_question)")
+        li.list-item.row.p-1(v-for="lotQuestion in lotQuestions", key="lot_question.question", @click="editLotQuestionPath(lotQuestion)")
           .container
             .list-title
-              | {{ lot_question.question }}
-            span(v-if="lot_question.answer")
-              | {{ lot_question.answer }}
+              | {{ lotQuestion.question }}
+            span(v-if="lotQuestion.answer")
+              | {{ lotQuestion.answer }}
             span(v-else)
               | {{ $t('.waiting_answer') }}
+
+    span(v-if="this.lotQuestionsCount == 0")
+      | {{ $t('.no_lot_questions') }}
+
 </template>
 
 <script>
@@ -22,8 +26,32 @@
     data () {
       return {
         i18nScope: 'biddings.lots.lot_questions.index',
-        lot_questions: null,
-        isLoading: true
+        lotQuestions: null,
+        lotQuestionsCount: 0,
+        isLoading: true,
+
+        tabs: [
+          {
+            route: { name: 'bidding', params: {} },
+            icon: 'fa-file',
+            text: this.$t('models.bidding.one'),
+            active: false,
+          },
+
+          {
+            route: { name: 'lots', params: { bidding_id: null } },
+            icon: 'fa-list',
+            text: this.$t('biddings.lots.index.tabs.lots'),
+            active: true,
+          },
+
+          {
+            route: { name: 'invites', params: {} },
+            icon: 'fa-envelope',
+            text: this.$t('biddings.lots.index.tabs.invites'),
+            active: false,
+          }
+        ]
       }
     },
 
@@ -33,7 +61,8 @@
 
         return this.$http.get('/cooperative/biddings/' + this.biddingId + '/lots/' + this.lotId + '/lot_questions')
           .then((response) => {
-            this.lot_questions = response.data
+            this.lotQuestions = response.data
+            this.lotQuestionsCount = this.lotQuestions.length
             this.isLoading = false
 
           }).catch((_err) => {
@@ -55,8 +84,22 @@
         this.lotId = this.$params.asInteger(this.$route.params.lot_id)
       },
 
+      updateTabsRoutes() {
+        this.tabs[0].route.params = { id: this.biddingId }
+        this.tabs[1].route.params = { bidding_id: this.biddingId }
+        this.tabs[2].route.params = { bidding_id: this.biddingId, lot_id: this.lotId }
+
+        this.$emit('tabChanged', this.tabs)
+      },
+
+      updateTitle() {
+        this.$emit('navbarTitleChanged', this.$t('.title'))
+      },
+
       init() {
         this.parseRoute()
+        this.updateTitle()
+        this.updateTabsRoutes()
         this.fetch()
       }      
     },

--- a/src/views/biddings/lots/show.vue
+++ b/src/views/biddings/lots/show.vue
@@ -81,6 +81,10 @@
 
     lot-group-item-overlay(:showOverlay="showOverlay", :overlayItem="overlayItem", @closeOverlay="showOverlay = false")
 
+    .container
+      router-link.button.button-primary.router-link.mt-4.mb-0.u-full-width(:to="{ name: 'LotQuestions', params: { bidding_id: this.biddingId, lot_id: this.params.id } }")
+        | {{ $t('.button.lot_questions') }}
+
 </template>
 
 <script>

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -151,7 +151,7 @@
         | {{ $t('.cancel.button') }}
 
       //- XXX: Conforme solicitação do item 9 do Ciclo 4, foi removido o botão de concluir licitação fracassada, pois a licitação
-      //- será fracassada automaticamente. O cósgio foi comentado ao invés de ser removido, caso o botão seja necessário novamente. 
+      //- será fracassada automaticamente. O código foi comentado ao invés de ser removido, caso o botão seja necessário novamente. 
       //- .row
       //-   button.button-submit(v-if="canFinishFailureBidding" @click="showFailureOverlay = true")
       //-     | {{ $t('.failure.button') }}

--- a/src/views/contracts/show.vue
+++ b/src/views/contracts/show.vue
@@ -332,7 +332,6 @@
       },
 
       isSubmitButtonDisabled() {
-        console.log(this.contract)
         if (this.contract.inexecution_reason === undefined ||
             this.contract.inexecution_reason === null ||
             this.contract.inexecution_reason.replace(/\s/g,'') === '') {

--- a/src/views/contracts/show.vue
+++ b/src/views/contracts/show.vue
@@ -323,12 +323,14 @@
       },
 
       statuses() {
-        return [
+        let statues_items = [
           { id: 'signed', text: this.$t('options.blank') },
           { id: 'completed', text: this.$t('models.contract.attributes.statuses.completed') },
           { id: 'partial_execution', text: this.$t('models.contract.attributes.statuses.partial_execution') },
           { id: 'total_inexecution', text: this.$t('models.contract.attributes.statuses.total_inexecution') }
         ]
+
+        return this.contract.lot_group_item_count === 1 ? statues_items.filter(item => item.id !== 'partial_execution') : statues_items
       },
 
       isSubmitButtonDisabled() {

--- a/src/views/notifications/index.vue
+++ b/src/views/notifications/index.vue
@@ -133,6 +133,7 @@
         if((/^(invite)/i).test(action)) return this.invitesRoute(notification)
         if((/^(proposal\.lot)/i).test(action)) return this.lotProposalsRoute(notification)
         if((/^(proposal)/i).test(action)) return this.globalProposalsRoute(notification)
+        if((/^(lot_question)/i).test(action)) return this.lotQuestionsRoute(notification)
       },
 
       contractRoute(notification) {
@@ -159,6 +160,12 @@
         let args = notification.args
 
         return { name: 'globalProposals', params: { bidding_id: args.bidding_id } }
+      },
+
+      lotQuestionsRoute(notification) {
+        let args = notification.args
+
+        return { name: 'LotQuestions', params: { bidding_id: args.bidding_id, lot_id: args.lot_id } }
       },
 
       clickedNotification(notification) {


### PR DESCRIPTION
Tarefas:

- [Item 10] Quando o item do lote é único, não permitir a situação do contrato "Executado Parcialmente"
  - A associação ao atualizar o status do contrato, se a licitação tiver apenas um item no lote não deve aparecer a opção "Executado Parcialmente"

- [Item 21] Criação de campo no módulo do Fornecedor para solicitação de esclarecimento
  - Adição de botão de Esclarecimentos no lote de uma licitação para todos os perfis
  - O fornecedor pode enviar esclarecimentos até 2 dias antes do prazo de fechamento da licitação
  - A associação pode responder aos esclarecimentos
  - O Administrador e revisor poderão visualizar as perguntas e respostas
  - Uma notificação é enviada à cada pergunta e resposta criada