### PR TITLE
[Bug] Correção da exibição co campo "Motivo" na execução parcial

### DIFF
--- a/src/views/contracts/partial_execution/edit.vue
+++ b/src/views/contracts/partial_execution/edit.vue
@@ -79,11 +79,12 @@
                   :error="errors[item.index] && errors[item.index]['quantity']"
                 )
 
-              textarea-field.mb-0(
-                type="text",
-                v-model="contract.inexecution_reason",
-                name="contract[inexecution_reason]"
-              )
+          .card.mb-2
+            textarea-field.mb-0(
+              type="text",
+              v-model="contract.inexecution_reason",
+              name="contract[inexecution_reason]"
+            )
 
         button.button-primary.u-full-width(
           type="submit",


### PR DESCRIPTION
- O campo "Motivo" na execução parcial estava sendo duplicado para cada item do contrato. Foi ajustado para que aparecesse apenas uma vez.

---

![image](https://user-images.githubusercontent.com/8549327/159186884-337a41d2-b734-4aff-b4d1-ad37b37d0683.png)
